### PR TITLE
fix(ToDoController): Change Package structure

### DIFF
--- a/src/main/java/todo/demo/web/TodoController.java
+++ b/src/main/java/todo/demo/web/TodoController.java
@@ -1,7 +1,6 @@
 package todo.demo.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,13 +12,14 @@ import java.util.List;
 
 @RestController
 public class TodoController {
-//    @Autowired
+
+    @Autowired
     TodoRepository todoRepository;
 
     @GetMapping("/")
     public String index (Model model) {
-//        List<Todo> todos = todoRepository.findAll();
-//        model.addAttribute("todos",todos);
+        List<Todo> todos = todoRepository.findAll();
+        model.addAttribute("todos",todos);
         return "index";
     }
 

--- a/src/test/java/todo/demo/web/TodoControllerTest.java
+++ b/src/test/java/todo/demo/web/TodoControllerTest.java
@@ -1,24 +1,20 @@
-package web;
+package todo.demo.web;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import todo.demo.repository.TodoRepository;
-import todo.demo.web.TodoController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {TodoControllerTest.class, TodoController.class})
-@AutoConfigureMockMvc
+@SpringBootTest
 public class TodoControllerTest {
 
     @Autowired


### PR DESCRIPTION
1. Controller -> RestController 변경
2. ToDoControllerTest가 위치한 package의 위치를 source code package 구조와 동일하게 변경함
- SpringBootTest 가 찾지 못해서 Class를 따로 지정해주어야 했음